### PR TITLE
Java 6 compatability, don't force xz

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <target>1.7</target>
-                        <source>1.7</source>
+                        <target>1.6</target>
+                        <source>1.6</source>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -50,12 +50,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.4.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.tukaani</groupId>
-            <artifactId>xz</artifactId>
-            <version>1.2</version>
+            <version>1.5</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jbsdiff/Patch.java
+++ b/src/main/java/org/jbsdiff/Patch.java
@@ -100,8 +100,6 @@ public class Patch {
 
             out.write(output);
 
-        } catch (Exception e) {
-            throw e;
         } finally {
             controlIn.close();
             dataIn.close();

--- a/src/main/java/org/jbsdiff/ui/CLI.java
+++ b/src/main/java/org/jbsdiff/ui/CLI.java
@@ -65,21 +65,20 @@ public class CLI {
     }
 
     public static void printUsage() {
-        String nl = System.lineSeparator();
-        String usage = "" +
-                "Usage: COMMAND oldfile newfile patchfile" + nl + nl +
+        String usage = String.format("" +
+                "Usage: COMMAND oldfile newfile patchfile%n%n" +
 
-                "Where COMMAND is either 'diff' or 'patch.'" + nl + nl +
+                "Where COMMAND is either 'diff' or 'patch.'%n%n" +
 
-                "The jbsdiff.compressor property can be used to select a different " + nl +
-                "compression scheme at runtime:" + nl + nl +
+                "The jbsdiff.compressor property can be used to select a different %n" +
+                "compression scheme at runtime:%n%n" +
 
                 "    java -Djbsdiff.compressor=gz -jar jbsdiff-?.?.jar diff " +
-                "a.bin b.bin patch.gz" + nl + nl +
-                "Supported compression schemes: bzip2 (default), gz, pack200, xz." + nl + nl +
-                "The compression algorithm used will be detected automatically during " + nl +
-                "patch operations.  NOTE: algorithms other than bzip2 are incompatible " + nl +
-                "with the reference implementation of bsdiff!";
+                "a.bin b.bin patch.gz%n%n" +
+                "Supported compression schemes: bzip2 (default), gz, pack200, xz.%n%n" +
+                "The compression algorithm used will be detected automatically during %n" +
+                "patch operations.  NOTE: algorithms other than bzip2 are incompatible %n" +
+                "with the reference implementation of bsdiff!");
 
         System.out.println(usage);
         System.exit(1);


### PR DESCRIPTION
commons-compress already depends (optionally) on xz, so no need to repeat the dependency here.

Also removed the use of Java 7 features (which actually makes the code cleaner!). Java 6 still occurs quite a bit in the wild, and there's no need to force Java 7 when we aren't really using anything that is 7 specific.