### PR TITLE
Code quality fix - Strings literals should be placed on the left side when checking for equality.

### DIFF
--- a/src/main/java/io/sigpipe/jbsdiff/Header.java
+++ b/src/main/java/io/sigpipe/jbsdiff/Header.java
@@ -71,7 +71,7 @@ class Header {
 
         headerIn.read(buf);
         magic = new String(buf);
-        if (!magic.equals("BSDIFF40")) {
+        if (!"BSDIFF40".equals(magic)) {
             throw new InvalidHeaderException("Header missing magic number");
         }
 

--- a/src/main/java/io/sigpipe/jbsdiff/ui/CLI.java
+++ b/src/main/java/io/sigpipe/jbsdiff/ui/CLI.java
@@ -49,9 +49,9 @@ public class CLI {
             File newFile = new File(args[2]);
             File patchFile = new File(args[3]);
 
-            if (command.equals("diff")) {
+            if ("diff".equals(command)) {
                 FileUI.diff(oldFile, newFile, patchFile, compression);
-            } else if (command.equals("patch")) {
+            } else if ("patch".equals(command)) {
                 FileUI.patch(oldFile, newFile, patchFile);
             } else {
                 printUsage();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Faisal Hameed