### PR TITLE
Code quality fix - Throws declarations should not be superfluous.

### DIFF
--- a/src/main/java/io/sigpipe/jbsdiff/ui/FileUI.java
+++ b/src/main/java/io/sigpipe/jbsdiff/ui/FileUI.java
@@ -48,15 +48,13 @@ import io.sigpipe.jbsdiff.Patch;
 public class FileUI {
 
     public static void diff(File oldFile, File newFile, File patchFile)
-    throws CompressorException, FileNotFoundException, InvalidHeaderException,
-            IOException {
+    throws CompressorException, InvalidHeaderException, IOException {
         diff(oldFile, newFile, patchFile, CompressorStreamFactory.BZIP2);
     }
 
     public static void diff(File oldFile, File newFile, File patchFile,
                             String compression)
-    throws CompressorException, FileNotFoundException, InvalidHeaderException,
-            IOException {
+    throws CompressorException, InvalidHeaderException, IOException {
         FileInputStream oldIn = new FileInputStream(oldFile);
         byte[] oldBytes = new byte[(int) oldFile.length()];
         oldIn.read(oldBytes);
@@ -74,8 +72,7 @@ public class FileUI {
     }
 
     public static void patch(File oldFile, File newFile, File patchFile)
-    throws CompressorException, FileNotFoundException, InvalidHeaderException,
-            IOException {
+    throws CompressorException, InvalidHeaderException, IOException {
         Patch.patch(oldFile, newFile, patchFile);
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:RedundantThrowsDeclarationCheck- Throws declarations should not be superfluous.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck

Please let me know if you have any questions.

Faisal Hameed