### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/io/sigpipe/jbsdiff/Diff.java
+++ b/src/main/java/io/sigpipe/jbsdiff/Diff.java
@@ -44,6 +44,8 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
  * @author malensek
  */
 public class Diff {
+	
+	private Diff() {}
 
     /**
      * Using two different versions of a file, generate a bsdiff patch that can

--- a/src/main/java/io/sigpipe/jbsdiff/Offset.java
+++ b/src/main/java/io/sigpipe/jbsdiff/Offset.java
@@ -43,6 +43,8 @@ class Offset {
      * Size of a bsdiff-encoded offset, in bytes.
      */
     public static final int OFFSET_SIZE = 8;
+    
+    private Offset() {}
 
     /**
      * Reads a bsdiff-encoded offset (based on the C off_t type) from an

--- a/src/main/java/io/sigpipe/jbsdiff/Patch.java
+++ b/src/main/java/io/sigpipe/jbsdiff/Patch.java
@@ -45,6 +45,8 @@ import java.io.OutputStream;
  * @author malensek
  */
 public class Patch {
+	
+	private Patch() {}
 
     /**
      * Using an old file and its accompanying patch, this method generates a new

--- a/src/main/java/io/sigpipe/jbsdiff/sort/SuffixSort.java
+++ b/src/main/java/io/sigpipe/jbsdiff/sort/SuffixSort.java
@@ -31,6 +31,9 @@ package io.sigpipe.jbsdiff.sort;
  * @author malensek
  */
 public class SuffixSort {
+	
+	private SuffixSort() {}
+	
     public static void qsufsort(int[] I, int[] V, byte[] data) {
         int[] buckets = new int[256];
         int i, h, len;

--- a/src/main/java/io/sigpipe/jbsdiff/ui/CLI.java
+++ b/src/main/java/io/sigpipe/jbsdiff/ui/CLI.java
@@ -33,6 +33,8 @@ import java.io.File;
  * @author malensek
  */
 public class CLI {
+	
+	private CLI() {}
 
     public static void main(String[] args) throws Exception {
         if (args.length < 4) {

--- a/src/main/java/io/sigpipe/jbsdiff/ui/FileUI.java
+++ b/src/main/java/io/sigpipe/jbsdiff/ui/FileUI.java
@@ -46,6 +46,8 @@ import io.sigpipe.jbsdiff.Patch;
  * @author malensek
  */
 public class FileUI {
+	
+	private FileUI() {};
 
     public static void diff(File oldFile, File newFile, File patchFile)
     throws CompressorException, FileNotFoundException, InvalidHeaderException,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed