### PR TITLE
Remove invalid compiler argument '-Xpkginfo:always'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,6 @@
                     <target>${jdk.version}</target>
 
                     <compilerArgument>-Xlint:all</compilerArgument>
-                    <compilerArgument>-Xpkginfo:always</compilerArgument>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                 </configuration>


### PR DESCRIPTION
jitpack.io fails to build the project:

    Java version: 1.6.0_45, vendor: Sun Microsystems Inc.
    Fatal error compiling: invalid flag: -Xpkginfo:always

See https://jitpack.io/com/github/malensek/jbsdiff/54a9e2eb45/build.log