### PR TITLE
Remove zero bytes after diff and extra data

### DIFF
--- a/src/main/java/io/sigpipe/jbsdiff/Diff.java
+++ b/src/main/java/io/sigpipe/jbsdiff/Diff.java
@@ -225,13 +225,13 @@ public class Diff {
 
         patchOut =
                 compressor.createCompressorOutputStream(compression, byteOut);
-        patchOut.write(db);
+        patchOut.write(db, 0, dblen);
         patchOut.close();
         header.setDiffLength(byteOut.size() - header.getControlLength());
 
         patchOut =
                 compressor.createCompressorOutputStream(compression, byteOut);
-        patchOut.write(eb);
+        patchOut.write(eb, 0, eblen);
         patchOut.close();
 
         header.setOutputLength(newBytes.length);


### PR DESCRIPTION
jbsdiff seems to write one extra zero byte for every byte in the
target binary to the compressed stream. While these are mostly
compressed away (and not consumed by bspatch or jbsdiff patch), 
it will still make the patches slightly smaller and the patching
slightly faster to not write them.

This should make jbsdiff's patches more similar to those generated
by bsdiff. However, even after this change, both library seem
to generate slighly different patch files.